### PR TITLE
Downgrage docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.2
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
 RUN apk --update add docker bash && \


### PR DESCRIPTION
## WHY

This crontab -docker use docker remote api v1.21(newer version).
need to version up docker in server.
The client(crontab-docker), I want to make it work with one previous version.
