### PR TITLE
Use JST timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM gliderlabs/alpine:3.3
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
-RUN apk --update add docker && \
+RUN apk --update add docker tzdata && \
+    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
+    echo "Asia/Tokyo" > /etc/timezone && \
+    apk del tzdata && \
     rm -rf /var/cache/apk/*
 
 COPY docker-entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## WHY and WHAT

Our cron tasks are based on JST (UTC+9). Therefore this container should run in JST.
## REF

[Setting the timezone - Alpine Linux](http://wiki.alpinelinux.org/wiki/Setting_the_timezone)
