### PR TITLE
Dockerfileで生成されるコンテナのテストを行う

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+env:
+  - TARGET_CONTAINER_ID=container-crontab
+
+before_script:
+  - docker build -t crontab .
+  - docker run -d --name $TARGET_CONTAINER_ID crontab
+
+script:
+  - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_script:
   - docker build -t crontab .
   - docker run -d --name $TARGET_CONTAINER_ID crontab
+  - docker exec -it $TARGET_CONTAINER_ID docker -v
 
 script:
-  - docker -v
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ before_script:
   - docker run -d --name $TARGET_CONTAINER_ID crontab
 
 script:
+  - docker -v
   - bundle exec rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
 RUN apk --update add bash docker tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    echo "Asia/Tokyo" > /etc/timezone && \
     apk del tzdata && \
     rm -rf /var/cache/apk/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'serverspec'
+gem 'docker-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    docker-api (1.26.0)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
+    json (1.8.3)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.2)
+    net-telnet (0.1.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.2)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    serverspec (2.29.1)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.48)
+    sfl (2.2)
+    specinfra (2.50.4)
+      net-scp
+      net-ssh (>= 2.7, < 3.1)
+      net-telnet
+      sfl
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker-api
+  serverspec
+
+BUNDLED WITH
+   1.11.2

--- a/spec/cron_spec.rb
+++ b/spec/cron_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe service('crond') do
+  it { should be_running }
+end

--- a/spec/cron_spec.rb
+++ b/spec/cron_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe service('crond') do
+describe process('cron') do
   it { should be_running }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+set :backend, :docker
+set :docker_url, ENV['DOCKER_HOST']
+set :docker_container, ENV['TARGET_CONTAINER_ID']

--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+set :backend, :exec
+
+describe command('date') do
+  its(:stdout) { should match /JST/ }
+end
+
+describe command('strings /etc/localtime') do
+  its(:stdout) { should match /JST-9/ }
+end
+
+describe file('/etc/timezone') do
+  its(:content) { should match /Asia\/Tokyo/ }
+end

--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -3,11 +3,3 @@ require 'spec_helper'
 describe command('date') do
   its(:stdout) { should match /JST/ }
 end
-
-describe command('strings /etc/localtime') do
-  its(:stdout) { should match /JST-9/ }
-end
-
-describe file('/etc/timezone') do
-  its(:content) { should match /Asia\/Tokyo/ }
-end

--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-set :backend, :exec
 
 describe command('date') do
   its(:stdout) { should match /JST/ }


### PR DESCRIPTION
## REF

https://github.com/wantedly/infrastructure/issues/794
## WHY

buildされたコンテナのテストがされていない。  
## WHAT

Travis CI + Serverspec環境でコンテナのテストを行うようにした。
コンテナにインストールされているDockerのバージョンをTravis CIに表示するようにした。
### テスト項目
- timezoneがJSTであるか。
- crondがプロセスに存在するか。
### テスト結果

https://travis-ci.org/wantedly/dockerfile-crontab-docker/builds/107716143
