### PR TITLE
Do not ignore Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
+!Dockerfile
 !docker-entrypoint.sh


### PR DESCRIPTION
## WHY

Recent builds on Quay.io were failed because `Dockerfile` wasn't included in Docker context.
## WHAT

Include `Dockerfile` in Docker context.
