### PR TITLE
Fail if crontab file is not provided / does not exist

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 crontab $1
 crond -f

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,5 +2,10 @@
 
 set -e
 
+if [[ $# -lt 1 ]]; then
+  echo "ERROR: crontab file must be provided." >&2
+  exit 1
+fi
+
 crontab $1
 crond -f


### PR DESCRIPTION
## WHY

Even if provided crontab file does not exist, crontab container does not stop and is still running.
## WHAT

Fail and stop container immediately if crontab file does not exist.
